### PR TITLE
Build Arch Linux 32 images

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -41,6 +41,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7 # TODO: 32-bit x86 (linux/386)
+          platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.tags.outputs.NAME }}:latest,${{ steps.tags.outputs.NAME }}:${{ steps.tags.outputs.DATE }}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Unofficial, automated Docker multi-platform images of Arch Linux for the followi
 | x86_64 | `linux/amd64` | [Arch Linux](https://archlinux.org) |
 | aarch64 | `linux/arm64` | [Arch Linux ARM](https://archlinuxarm.org) |
 | armv7h | `linux/arm/v7` | [Arch Linux ARM](https://archlinuxarm.org) |
+| pentium4 | `linux/386` | [Arch Linux 32](https://archlinux32.org) |

--- a/rootfs/386/etc/pacman.conf
+++ b/rootfs/386/etc/pacman.conf
@@ -19,7 +19,7 @@ HoldPkg     = pacman glibc
 #XferCommand = /usr/bin/curl -L -C - -f -o %o %u
 #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
 #CleanMethod = KeepInstalled
-Architecture = auto
+Architecture = pentium4
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
 #IgnorePkg   =

--- a/rootfs/amd64/etc/pacman.conf
+++ b/rootfs/amd64/etc/pacman.conf
@@ -19,7 +19,7 @@ HoldPkg     = pacman glibc
 #XferCommand = /usr/bin/curl -L -C - -f -o %o %u
 #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
 #CleanMethod = KeepInstalled
-Architecture = auto
+Architecture = x86_64
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
 #IgnorePkg   =


### PR DESCRIPTION
This adds `linux/386` as a platform to the image.